### PR TITLE
Print out the logical resource ids of matching resource types

### DIFF
--- a/lib/cloudformation_rspec/matchers/change_set.rb
+++ b/lib/cloudformation_rspec/matchers/change_set.rb
@@ -44,8 +44,10 @@ RSpec::Matchers.define :contain_in_change_set do |resource_type, resource_id|
     end
 
     if !change_set_result.changes.any? { |change| change.logical_resource_id == resource_id }
-      @error = "Change set does not include a resource type #{resource_type} with the id #{resource_id}
-      Found the following resources with the same Resource Type:\n#{resource_ids_with_resource_type(change_set_result, resource_type)}"
+      @error = %Q(
+Change set does not include a resource type #{resource_type} with the id #{resource_id}
+Found the following resources with the same Resource Type:\n#{resource_ids_with_resource_type(change_set_result, resource_type).join("\n")}
+      )
       return false
     end
     true


### PR DESCRIPTION
When setting up these tests I found it hard to determine what the names are meant to be for my resources. The current output is not very helpful:

```
  1) vpc_template public subnets creates a route table and association
     Failure/Error: expect(stack).to contain_in_change_set("AWS::EC2::SubnetRouteTableAssociation", "MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnetsRouteTableRouteTableAssociation")
       Change set does not include a resource type AWS::EC2::SubnetRouteTableAssociation with the id MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnetsRouteTableRouteTableAssociation
```

Instead we should output all the resource names with the same resource type, to give us a handy hint:

```
  1) vpc_template public subnets creates a route table and association
     Failure/Error: expect(stack).to contain_in_change_set("AWS::EC2::SubnetRouteTableAssociation", "MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnetsRouteTableRouteTableAssociation")

       Change set does not include a resource type AWS::EC2::SubnetRouteTableAssociation with the id MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnetsRouteTableRouteTableAssociation
       Found the following resources with the same Resource Type:
       MyAwesomeVpcYouShouldTotallyChangeThisPrivateSubnet0RouteTableAssociation
       MyAwesomeVpcYouShouldTotallyChangeThisPrivateSubnet1RouteTableAssociation
       MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnet0RouteTableAssociation
       MyAwesomeVpcYouShouldTotallyChangeThisPublicSubnet1RouteTableAssociation
```