### PR TITLE
Lint templates as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
-rvm:
- - 2.3.7
- - 2.4.4
- - 2.5.1
-script: bundle exec rake spec
+
+services:
+  - docker
+
+before_install:
+  - docker build -t cloudformation_rspec -f Dockerfile.ci .
+
+script:
+  - docker run cloudformation_rspec  /bin/sh -c "bundle exec rake spec"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,10 @@
+FROM ruby:2.6.5-slim
+
+RUN apt update -y && apt install -y python-pip git && pip install cfn-lint
+
+COPY . /app
+WORKDIR /app
+
+RUN bundle install
+
+

--- a/lib/cloudformation_rspec/matchers/validate.rb
+++ b/lib/cloudformation_rspec/matchers/validate.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-cloudformation'
+require 'open3'
 
 module CloudFormationRSpec::Matchers::Validate
   def validate_cf_template(template_body)
@@ -11,12 +12,34 @@ module CloudFormationRSpec::Matchers::Validate
     end
     true
   end
+
+  def lint_cf_template(template_body)
+    # Issue a warning if cfn-lint is not installed, but pass the test
+    unless cfn_lint_available
+      warn "Failed to run cfn-lint, do you have it installed and available in $PATH?"
+      true
+    end
+
+    Tempfile.open(['cfn-lint', '.json']) do |f|
+      f.write(template_body)
+      f.flush
+      _, stderr, status = Open3.capture3('cfn-lint', f.path)
+      if !status
+        @error = stderr
+      end
+      status
+    end
+  end
+
+  def cfn_lint_available
+    !system('cfn-lint', '--version').nil?
+  end
 end
 
 RSpec::Matchers.define :be_valid do
   include CloudFormationRSpec::Matchers::Validate
   match do |cf_template|
-    validate_cf_template(cf_template)
+    validate_cf_template(cf_template) && lint_cf_template(cf_template)
   end
 
   failure_message do
@@ -39,7 +62,7 @@ RSpec::Matchers.define :be_valid_sparkleformation do
       @error = error
       return false
     end
-    validate_cf_template(template_body)
+    validate_cf_template(template_body) && lint_cf_template(template_body)
   end
 
   failure_message do

--- a/lib/cloudformation_rspec/matchers/validate.rb
+++ b/lib/cloudformation_rspec/matchers/validate.rb
@@ -17,7 +17,7 @@ module CloudFormationRSpec::Matchers::Validate
     # Issue a warning if cfn-lint is not installed, but pass the test
     unless cfn_lint_available
       warn "Failed to run cfn-lint, do you have it installed and available in $PATH?"
-      true
+      return true
     end
 
     Tempfile.open(['cfn-lint', '.json']) do |f|

--- a/lib/cloudformation_rspec/matchers/validate.rb
+++ b/lib/cloudformation_rspec/matchers/validate.rb
@@ -23,11 +23,11 @@ module CloudFormationRSpec::Matchers::Validate
     Tempfile.open(['cfn-lint', '.json']) do |f|
       f.write(template_body)
       f.flush
-      _, stderr, status = Open3.capture3('cfn-lint', f.path)
-      if !status
-        @error = stderr
+      stdout, _stderr, status = Open3.capture3('cfn-lint', '-i', 'W', '--', f.path)
+      if status.exitstatus != 0
+        @error = stdout
       end
-      status
+      status.exitstatus == 0
     end
   end
 

--- a/lib/cloudformation_rspec/matchers/validate.rb
+++ b/lib/cloudformation_rspec/matchers/validate.rb
@@ -32,7 +32,8 @@ module CloudFormationRSpec::Matchers::Validate
   end
 
   def cfn_lint_available
-    !system('cfn-lint', '--version').nil?
+    _, _, status = Open3.capture3('cfn-lint', '-l')
+    status.exitstatus == 0
   end
 end
 

--- a/spec/fixtures/invalid_lint_template.json
+++ b/spec/fixtures/invalid_lint_template.json
@@ -1,21 +1,20 @@
 {
-    "AWSTemplateFormatVersion" : "2010-09-09",
-    "Resources" : {
-       "myVPC" : {
-          "Type" : "AWS::EC2::VPC",
-          "Properties" : {
-            "CidrBlock" : 1,
-            "EnableDnsSupport" : [],
-            "EnableDnsHostnames" : [],
-            "InstanceTenancy" : {},
-            "Tags" : [ {"Key" : "foo", "Value" : "bar"} ]
-          }
-       }
-    },
-    "Outputs" : {
-      "VpcId": {
-        "Value": {"Ref": "myVPC"}
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Resources" : {
+      "myVPC" : {
+        "Type" : "AWS::EC2::VPC",
+        "Properties" : {
+          "CidrBlock" : 1,
+          "EnableDnsSupport" : [],
+          "EnableDnsHostnames" : [],
+          "InstanceTenancy" : {},
+          "Tags" : [ {"Key" : "foo", "Value" : "bar"} ]
+        }
       }
+  },
+  "Outputs" : {
+    "VpcId": {
+      "Value": {"Ref": "myVPC"}
     }
-  }    
-  
+  }
+}

--- a/spec/fixtures/invalid_lint_template.json
+++ b/spec/fixtures/invalid_lint_template.json
@@ -1,0 +1,21 @@
+{
+    "AWSTemplateFormatVersion" : "2010-09-09",
+    "Resources" : {
+       "myVPC" : {
+          "Type" : "AWS::EC2::VPC",
+          "Properties" : {
+            "CidrBlock" : 1,
+            "EnableDnsSupport" : [],
+            "EnableDnsHostnames" : [],
+            "InstanceTenancy" : {},
+            "Tags" : [ {"Key" : "foo", "Value" : "bar"} ]
+          }
+       }
+    },
+    "Outputs" : {
+      "VpcId": {
+        "Value": {"Ref": "myVPC"}
+      }
+    }
+  }    
+  

--- a/spec/fixtures/template_with_compile_parameters.rb
+++ b/spec/fixtures/template_with_compile_parameters.rb
@@ -13,4 +13,11 @@ SparkleFormation.new(:vpc,
     constraint_description 'CIDR block parameter must be in the form x.x.x.x/16-28'
     default state!(:vpc_cidr)
   end
+
+  resources.vpc do
+    type "AWS::EC2::VPC"
+    properties do
+      cidr_block ref!(:vpc_cidr)
+    end
+  end
 end

--- a/spec/fixtures/valid_sparkle_vpc_template.rb
+++ b/spec/fixtures/valid_sparkle_vpc_template.rb
@@ -2,7 +2,7 @@ SparkleFormation.new(:vpc) do
   resources.vpc do
     type "AWS::EC2::VPC"
     properties do
-      cidr "10.0.0.0/16"
+      cidr_block "10.0.0.0/16"
     end
   end
 

--- a/spec/matchers/validate_spec.rb
+++ b/spec/matchers/validate_spec.rb
@@ -26,6 +26,17 @@ describe 'be_valid' do
       expect(template).not_to be_valid
     end
   end
+
+  context "the stack fails linting" do
+    let(:template) { File.join('spec', 'fixtures', 'invalid_lint_template.json') }
+    before do
+      allow(cf_stub).to receive(:validate_template)
+    end
+
+    it 'succeeds' do
+      expect(template).not_to be_valid
+    end
+  end
 end
 
 describe 'be_valid_sparkleformation' do


### PR DESCRIPTION
CloudFormation Validate only checks if the top level properties are valid
It does not check deeply nested parameters against the underlying API Schema
cfn-lint, a python tool, does perform deeply nested API Schema validation.
But we need to install it separately.

This PR implements using cfn-lint only if it's installed. Otherwise we just issue a warning, but pass the tests.